### PR TITLE
Correct font spacing

### DIFF
--- a/src/screen.rs
+++ b/src/screen.rs
@@ -187,11 +187,10 @@ impl OledScreen {
         let mut x_cursor = x;
 
         for letter in text.chars() {
-            let width = font.metrics(letter, size).width;
+            let letter_metrics = font.metrics(letter, size);
             self.draw_letter(letter, x_cursor, y, size, &font);
 
-            // FIXME: Use horizontal kerning as opposed to abstract value of "2"
-            x_cursor += width + 2
+            x_cursor += letter_metrics.advance_width as usize;
         }
     }
 

--- a/src/screen.rs
+++ b/src/screen.rs
@@ -190,7 +190,7 @@ impl OledScreen {
             let letter_metrics = font.metrics(letter, size);
             self.draw_letter(letter, x_cursor, y, size, &font);
 
-            x_cursor += letter_metrics.advance_width as usize;
+            x_cursor += letter_metrics.advance_width.round() as usize;
         }
     }
 


### PR DESCRIPTION
Previously a fixed distance of 2 pixels was put between each letter. This PR pulls the correct width from the font metrics and uses a rounded version of that instead